### PR TITLE
Added possibility to customize images

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,23 +62,23 @@ defaults:
   # + most reliable and well tested
   # + very scalable. communicates to docker daemon for heavy lifting
   # - least secure. requires docker.sock of host to be mounted (often rejected by OPA)
-  # 
+  #
   #     Kubelet
-  # 
+  #
   # + secure. cannot escape privileges of pod's service account
   # + medium scalability - log retrieval and container polling is done against kubelet
   # - additional kubelet configuration may be required
   # - can only save params/artifacts in volumes (e.g. emptyDir), and not the base image layer (e.g. /tmp)
-  # 
+  #
   #     K8s API
-  # 
+  #
   # + secure. cannot escape privileges of pod's service account
   # + no extra configuration
   # - least scalable - log retrieval and container polling is done against k8s API server
   # - can only save params/artifacts in volumes (e.g. emptyDir), and not the base image layer (e.g. /tmp)
-  # 
+  #
   #     PNS
-  # 
+  #
   # + secure. cannot escape privileges of service account
   # + artifact collection can be collected from base image layer
   # + scalable - process polling is done over procfs and not kubelet/k8s API
@@ -113,7 +113,11 @@ defaults:
 extra:
   # Argo reference to use
   # Can be a branch, tag or a specific commit (defaults to the latest release)
-  - ref 
+  - ref
+
+  # Allows to overwrite executor and workflow controller images
+  - executor_image
+  - workflow_controller_image
 
   # If s3 artifact repository is selected, a host (endpoint) and credentials are  required
   - AWS_S3_HOST
@@ -161,7 +165,7 @@ The role provides an option to add custom overlays via [Kustomize](https://kusto
     overlay: openshift
 ```
 
-Tested on minishift, [OpenShift 3.11](https://docs.openshift.com/container-platform/3.11/welcome/index.html). 
+Tested on minishift, [OpenShift 3.11](https://docs.openshift.com/container-platform/3.11/welcome/index.html).
 
 <br>
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,23 +21,23 @@ overlay: ""        # options: openshift
 # + most reliable and well tested
 # + very scalable. communicates to docker daemon for heavy lifting
 # - least secure. requires docker.sock of host to be mounted (often rejected by OPA)
-# 
+#
 #     Kubelet
-# 
+#
 # + secure. cannot escape privileges of pod's service account
 # + medium scalability - log retrieval and container polling is done against kubelet
 # - additional kubelet configuration may be required
 # - can only save params/artifacts in volumes (e.g. emptyDir), and not the base image layer (e.g. /tmp)
-# 
+#
 #     K8s API
-# 
+#
 # + secure. cannot escape privileges of pod's service account
 # + no extra configuration
 # - least scalable - log retrieval and container polling is done against k8s API server
 # - can only save params/artifacts in volumes (e.g. emptyDir), and not the base image layer (e.g. /tmp)
-# 
+#
 #     PNS
-# 
+#
 # + secure. cannot escape privileges of service account
 # + artifact collection can be collected from base image layer
 # + scalable - process polling is done over procfs and not kubelet/k8s API

--- a/templates/patch/custom-image.yaml
+++ b/templates/patch/custom-image.yaml
@@ -1,0 +1,13 @@
+- op: replace
+  path: /spec/template/spec/containers/0
+  value:
+    args:
+    - --configmap
+    - workflow-controller-configmap
+    - --executor-image
+    - {{ executor_image | default( "argoproj/argoexec:" + ref|default(latest) ) }}
+    command:
+    - workflow-controller
+    image: |-
+      {{ workflow_controller_image | default( "argoproj/workflow-controller:" + ref|default(latest) ) }}
+    name: workflow-controller

--- a/templates/patch/kustomization.yaml
+++ b/templates/patch/kustomization.yaml
@@ -5,6 +5,10 @@ patches:
   target:
     kind: Role
     name: argo-role
+- path: custom-image.yaml
+  target:
+    kind: Deployment
+    name: workflow-controller
 
 patchesStrategicMerge:
 - configmap.yaml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,4 +15,4 @@
 
   tasks:
   - import_role:
-      name: argo-workflows 
+      name: argo-workflows


### PR DESCRIPTION
Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   README.md
modified:   defaults/main.yml
modified:   templates/patch/kustomization.yaml
modified:   tests/test.yml
new file:   templates/patch/custom-image.yaml


## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Possibility to customize executor and workflow-controller images.

## Description

It can be useful to deploy Argo with a custom executor or workflow-controller image. We don't want to patch the resources manually, hence being able to pass this as a role parameter is highly beneficial.