### PR TITLE
Added RBAC to instantiate binary builds to argo-builder

### DIFF
--- a/templates/overlays/openshift/base/argo-builder.yaml
+++ b/templates/overlays/openshift/base/argo-builder.yaml
@@ -49,6 +49,16 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  - build.openshift.io
+  attributeRestrictions: null
+  resources:
+  - buildconfigs/instantiate
+  - buildconfigs/instantiatebinary
+  - builds/clone
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   templates/overlays/openshift/base/argo-builder.yaml

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Explanation

Argo Workflow was not able to instantiate binary build using the Argo SA
