### PR TITLE
Removed the namespace creation step

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,16 +19,6 @@
     - kustomize
     - kustomization
 
-- name: "create a namespace if not exists"
-  tags:
-    - deploy
-    - cluster-admin
-  k8s:
-    state: present
-    kind: Namespace
-    name: "{{ namespace }}"
-  when: role == "cluster-admin"
-
 - name: "deploy as cluster-admin"
   tags:
     - deploy


### PR DESCRIPTION
This step can cause a lot of trouble to depoyers without cluster-admin
access. Let there be an assumption that the namespace already exists.

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   tasks/main.yml