### PR TITLE
workflow-creator SA should not be bound to view

### DIFF
--- a/templates/base/view.yaml
+++ b/templates/base/view.yaml
@@ -1,15 +1,38 @@
-# Grant argo SA "view" access to the namespace
+# Grant argo SA "view-like" access to the namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workflow-creator
+  namespace: {{ namespace }}
+rules:
+- apiGroups:
+  - ""
+  attributeRestrictions: null
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     ansible/role: argo-workflows
-  name: view
+  name: workflow-creator
   namespace: {{ namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: view
+  kind: Role
+  name: workflow-creator
 subjects:
 - kind: ServiceAccount
   name: workflow-creator


### PR DESCRIPTION
Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   templates/base/view.yaml

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Description

Assigning `view` cluster role may cause troubles when the role is being used with other SAs which don't have access to other namespace resources. Currently, workflow-creator receives a set of basic RBAC permissions and the rest is left to the namespace admins to be configured.